### PR TITLE
Add page URL to edd_dict and remove redundant columns

### DIFF
--- a/data/edd_dict.csv
+++ b/data/edd_dict.csv
@@ -1,53 +1,53 @@
-type,provider,id,desc,url,eddie_file_loc,eddie_sql_loc,last_update,next_update,last_download,status,obj_available,notes
-lookup,ONSx,NSPL,National Statistics Postcode Lookup,NA,/ons/nspl,NA,NA,NA,NA,FALSE,FALSE,NA
-lookup,ONSx,NSAL,National Statistics Address Lookup,NA,/ons/nsal,NA,NA,NA,NA,FALSE,FALSE,NA
-lookup,ONSx,ONSPD,ONS Postcode Directory,NA,/ons/onspd,NA,NA,NA,NA,FALSE,FALSE,NA
-dataset,ONS,BB,"UK National Accounts, The Blue Book",https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/bluebook/current/bb.csv,/ons/datasets,NA,2023-10-31,NA,2024-04-24,TRUE,FALSE,NA
-dataset,ONS,CXNV,Business Investment,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/businessinvestment/current/cxnv.csv,/ons/datasets,NA,2024-08-15,2024-09-30,2024-08-16,TRUE,FALSE,NA
-dataset,ONS,DIOP,Index of Production,https://www.ons.gov.uk/file?uri=/economy/economicoutputandproductivity/output/datasets/indexofproduction/current/diop.csv,/ons/datasets,NA,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
-dataset,ONS,DRSI,Retail Sales Index,https://www.ons.gov.uk/file?uri=/businessindustryandtrade/retailindustry/datasets/retailsales/current/drsi.csv,/ons/datasets,NA,2024-08-16,2024-09-20,2024-08-16,TRUE,FALSE,NA
-dataset,ONS,EMP,Average Weekly Earnings,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/averageweeklyearnings/current/emp.csv,/ons/datasets,NA,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
-dataset,ONS,IOS1,Index of Services,https://www.ons.gov.uk/file?uri=/economy/economicoutputandproductivity/output/datasets/indexofservices/current/ios1.csv,/ons/datasets,NA,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
-dataset,ONS,LMS,Labour Market Statistics,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/datasets/labourmarketstatistics/current/lms.csv,/ons/datasets,NA,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
-dataset,ONS,MGDP,Monthly GDP,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/gdpmonthlyestimateuktimeseriesdataset/current/mgdp.csv,/ons/datasets,NA,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
-dataset,ONS,MM22,Producer Price Inflation,https://www.ons.gov.uk/file?uri=/economy/inflationandpriceindices/datasets/producerpriceindex/current/mm22.csv,/ons/datasets,NA,2024-08-14,2024-09-18,2024-08-14,TRUE,FALSE,NA
-dataset,ONS,MM23,Consumer Price Inflation,https://www.ons.gov.uk/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/mm23.csv,/ons/datasets,NA,2024-08-14,2024-09-18,2024-08-14,TRUE,FALSE,NA
-dataset,ONS,MRET,UK Trade,https://www.ons.gov.uk/file?uri=/economy/nationalaccounts/balanceofpayments/datasets/tradeingoodsmretsallbopeu2013timeseriesspreadsheet/current/mret.csv,/ons/datasets,NA,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
-dataset,ONS,PDGP,Preliminary Estimate of GDP,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/preliminaryestimateofgdp/current/pgdp.csv,/ons/datasets,NA,NA,NA,NA,FALSE,FALSE,Ceased publication April 2018
-dataset,ONS,PN2,GDP First Quarterly Estimate,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/secondestimateofgdp/current/pn2.csv,/ons/datasets,NA,NA,NA,NA,FALSE,FALSE,NA
-dataset,ONS,PRDY,Labour Productivity,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/labourproductivity/current/prdy.csv,/ons/datasets,NA,2024-02-15,NA,2024-04-24,TRUE,FALSE,NA
-dataset,ONS,PSE,Public Sector Employment,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/publicsectorpersonnel/datasets/publicsectoremploymenttimeseriesdataset/current/pse.csv,/ons/datasets,NA,2024-06-11,2024-09-10,2024-06-11,TRUE,FALSE,NA
-dataset,ONS,PUSF,Public Sector Finances,https://www.ons.gov.uk/file?uri=/economy/governmentpublicsectorandtaxes/publicsectorfinance/datasets/publicsectorfinances/current/pusf.csv,/ons/datasets,NA,2024-08-21,2024-09-20,2024-08-21,TRUE,FALSE,NA
-dataset,ONS,QNA,GDP Quarterly National Accounts,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/quarterlynationalaccounts/current/qna.csv,/ons/datasets,NA,2024-03-28,2024-05-10,2024-05-13,TRUE,FALSE,NA
-dataset,ONS,RPRD,Regional Productivity,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/regionalproductivitytimeseries/current/rprd.csv,/ons/datasets,NA,2023-06-20,NA,2024-04-24,TRUE,FALSE,NA
-dataset,ONS,TOPSI,Turnover in UK Production and GB Services,https://www.ons.gov.uk/file?uri=/businessindustryandtrade/manufacturingandproductionindustry/datasets/turnoverandordersintheproductionandservicesindustriesdataset/current/topsi.csv,/ons/datasets,NA,2017-11-10,NA,2024-04-24,TRUE,FALSE,NA
-dataset,ONS,UCST,Unit Labour Cost and Unit Wage Cost,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/unitlabourcostandunitwagecosttimeseries/current/ucst.csv,/ons/datasets,NA,2023-10-24,2024-01-15,2024-04-24,TRUE,FALSE,NA
-dataset,ONS,UKEA,UK Economic Accounts,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/unitedkingdomeconomicaccounts/current/ukea.csv,/ons/datasets,NA,2024-06-28,2024-09-30,2024-07-01,TRUE,FALSE,NA
-dataset,ONS,UNEM,Claimant Count and Vacancies,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/claimantcountandvacanciesdataset/current/unem.csv,/ons/datasets,NA,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
-dataset,ONSx,PROD_LAD,Regional Productivity (LAD),NA,NA,NA,NA,NA,NA,TRUE,FALSE,NA
-dataset,BOE,FEA,Custom,"https://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp?csv.x=yes&Datefrom=01/Jan/2005&Dateto=Now&SeriesCodes=IUMBEDR,IUMAMNPY,IUMAAMIJ,XUMAUSS,XUMAERS&CSVF=TN&UsingCodes=Y&VPD=Y&VFD=N",/boe/datasets,NA,NA,NA,NA,FALSE,FALSE,NA
-dataset,ONSx,RGVA,Regional GVA,NA,/ons/datasets,NA,NA,NA,NA,FALSE,TRUE,NA
-dataset,ONSx,RGVA_LAD,Regional GVA (LAD),NA,NA,NA,NA,NA,NA,NA,NA,NA
-dataset,ONSx,RGVAI,Regional GVA (Income components),NA,/ons/datasets,NA,2024-04-24,NA,2024-05-22,FALSE,FALSE,NA
-dataset,NOMIS,BRES,Business Register and Employment Survey,NA,/nomis/datasets,NA,NA,NA,NA,FALSE,TRUE,NA
-dataset,NOMIS,UKBC,UK Business Counts,NA,/nomis/datasets,NA,NA,NA,NA,FALSE,TRUE,NA
-boundaries,ONSx,oa11,Output Areas,NA,/boundaries/ons/oa11,NA,NA,NA,NA,FALSE,FALSE,NA
-boundaries,ONSx,lsoa11,Lower Layer Super Output Areas,NA,/boundaries/ons/lsoa11,NA,NA,NA,NA,FALSE,FALSE,NA
-boundaries,ONSx,msoa11,Middle Layer Super Output Areas,NA,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-geographies,ONSx,oa11,Output Areas,NA,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-geographies,ONSx,lsoa11,Lower Layer Super Output Areas,NA,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-geographies,ONSx,msoa11,Middle Layer Super Output Areas,NA,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-geographies,ONSx,lad,Local Authority Districts,NA,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-names,HOCL,msoanames,MSOA Names,https://houseofcommonslibrary.github.io/msoanames/MSOA-Names-Latest.csv,NA,NA,NA,NA,NA,FALSE,FALSE,NA
-dataset,ONSx,RGFCF,Regional Gross Fixed Capital Formation,NA,/ons/datasets,NA,2023-12-08,NA,2024-05-21,TRUE,FALSE,NA
-NA,VOA,CTSOP,Council Tax Stock of Properties,NA,NA,NA,NA,NA,NA,NA,TRUE,NA
-NA,ONSx,SAIE,Small area income estimates,NA,NA,NA,NA,NA,NA,NA,TRUE,NA
-NA,NOMIS,SAPE,Small area population estimates,NA,NA,NA,NA,NA,NA,NA,NA,NA
-NA,ONSx,HPSSA2,Median House Price by Property Type (MSOA),NA,NA,NA,NA,NA,NA,NA,NA,NA
-NA,TEST,TEST,TEST,NA,NA,NA,NA,NA,NA,NA,NA,NA
-NA,NOMIS,CC,Claimant Count,NA,NA,NA,NA,NA,NA,NA,NA,NA
-NA,ONSx,RGDHI,Regional Gross Disposable Household Income,NA,NA,NA,2023-09-14,NA,2024-05-21,NA,NA,NA
-NA,ONSx,RFDI,Regional Foreign Direct Investment,NA,NA,NA,NA,NA,NA,NA,NA,NA
-dataset,ONSx,CONS,Output in the Construction Industry,NA,NA,NA,2024-08-15,2024-09-11,2024-09-04,TRUE,TRUE,NA
-dataset,ONSx,INS1,Monthly Insolvencies by Type,NA,NA,NA,2024-08-20,2024-09-20,2024-09-04,FALSE,FALSE,NA
-dataset,ONSx,INS2,Monthly Insolvencies by Industry,NA,NA,NA,2024-04-26,2024-05-17,2024-04-29,FALSE,FALSE,NA
+type,provider,id,desc,page_url,url,last_update,next_update,last_download,status,obj_available,notes
+lookup,ONSx,NSPL,National Statistics Postcode Lookup,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+lookup,ONSx,NSAL,National Statistics Address Lookup,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+lookup,ONSx,ONSPD,ONS Postcode Directory,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+dataset,ONS,BB,"UK National Accounts, The Blue Book",https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/bluebook,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/bluebook/current/bb.csv,2023-10-31,NA,2024-04-24,TRUE,FALSE,NA
+dataset,ONS,CXNV,Business Investment,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/businessinvestment,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/businessinvestment/current/cxnv.csv,2024-08-15,2024-09-30,2024-08-16,TRUE,FALSE,NA
+dataset,ONS,DIOP,Index of Production,https://www.ons.gov.uk/economy/economicoutputandproductivity/output/datasets/indexofproduction,https://www.ons.gov.uk/file?uri=/economy/economicoutputandproductivity/output/datasets/indexofproduction/current/diop.csv,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
+dataset,ONS,DRSI,Retail Sales Index,https://www.ons.gov.uk/businessindustryandtrade/retailindustry/datasets/retailsales,https://www.ons.gov.uk/file?uri=/businessindustryandtrade/retailindustry/datasets/retailsales/current/drsi.csv,2024-08-16,2024-09-20,2024-08-16,TRUE,FALSE,NA
+dataset,ONS,EMP,Average Weekly Earnings,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/averageweeklyearnings,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/averageweeklyearnings/current/emp.csv,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
+dataset,ONS,IOS1,Index of Services,https://www.ons.gov.uk/economy/economicoutputandproductivity/output/datasets/indexofservices/current/ios1.csv,https://www.ons.gov.uk/file?uri=/economy/economicoutputandproductivity/output/datasets/indexofservices/current/ios1.csv,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
+dataset,ONS,LMS,Labour Market Statistics,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/datasets/labourmarketstatistics,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/datasets/labourmarketstatistics/current/lms.csv,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
+dataset,ONS,MGDP,Monthly GDP,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/gdpmonthlyestimateuktimeseriesdataset,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/gdpmonthlyestimateuktimeseriesdataset/current/mgdp.csv,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
+dataset,ONS,MM22,Producer Price Inflation,https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex/current/mm22.csv,https://www.ons.gov.uk/file?uri=/economy/inflationandpriceindices/datasets/producerpriceindex/current/mm22.csv,2024-08-14,2024-09-18,2024-08-14,TRUE,FALSE,NA
+dataset,ONS,MM23,Consumer Price Inflation,https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices/current/mm23.csv,https://www.ons.gov.uk/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/mm23.csv,2024-08-14,2024-09-18,2024-08-14,TRUE,FALSE,NA
+dataset,ONS,MRET,UK Trade,https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/tradeingoodsmretsallbopeu2013timeseriesspreadsheet,https://www.ons.gov.uk/file?uri=/economy/nationalaccounts/balanceofpayments/datasets/tradeingoodsmretsallbopeu2013timeseriesspreadsheet/current/mret.csv,2024-08-15,2024-09-11,2024-08-15,TRUE,FALSE,NA
+dataset,ONS,PDGP,Preliminary Estimate of GDP,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/preliminaryestimateofgdp,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/preliminaryestimateofgdp/current/pgdp.csv,NA,NA,NA,FALSE,FALSE,Ceased publication April 2018
+dataset,ONS,PN2,GDP First Quarterly Estimate,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/secondestimateofgdp/current/pn2.csv,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/secondestimateofgdp/current/pn2.csv,NA,NA,NA,FALSE,FALSE,NA
+dataset,ONS,PRDY,Labour Productivity,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/labourproductivity,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/labourproductivity/current/prdy.csv,2024-02-15,NA,2024-04-24,TRUE,FALSE,NA
+dataset,ONS,PSE,Public Sector Employment,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/publicsectorpersonnel/datasets/publicsectoremploymenttimeseriesdataset,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/publicsectorpersonnel/datasets/publicsectoremploymenttimeseriesdataset/current/pse.csv,2024-06-11,2024-09-10,2024-06-11,TRUE,FALSE,NA
+dataset,ONS,PUSF,Public Sector Finances,https://www.ons.gov.uk/economy/governmentpublicsectorandtaxes/publicsectorfinance/datasets/publicsectorfinances,https://www.ons.gov.uk/file?uri=/economy/governmentpublicsectorandtaxes/publicsectorfinance/datasets/publicsectorfinances/current/pusf.csv,2024-08-21,2024-09-20,2024-08-21,TRUE,FALSE,NA
+dataset,ONS,QNA,GDP Quarterly National Accounts,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/quarterlynationalaccounts,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/quarterlynationalaccounts/current/qna.csv,2024-03-28,2024-05-10,2024-05-13,TRUE,FALSE,NA
+dataset,ONS,RPRD,Regional Productivity,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/regionalproductivitytimeseries,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/regionalproductivitytimeseries/current/rprd.csv,2023-06-20,NA,2024-04-24,TRUE,FALSE,NA
+dataset,ONS,TOPSI,Turnover in UK Production and GB Services,https://www.ons.gov.uk/businessindustryandtrade/manufacturingandproductionindustry/datasets/turnoverandordersintheproductionandservicesindustriesdataset,https://www.ons.gov.uk/file?uri=/businessindustryandtrade/manufacturingandproductionindustry/datasets/turnoverandordersintheproductionandservicesindustriesdataset/current/topsi.csv,2017-11-10,NA,2024-04-24,TRUE,FALSE,NA
+dataset,ONS,UCST,Unit Labour Cost and Unit Wage Cost,https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/unitlabourcostandunitwagecosttimeseries,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/labourproductivity/datasets/unitlabourcostandunitwagecosttimeseries/current/ucst.csv,2023-10-24,2024-01-15,2024-04-24,TRUE,FALSE,NA
+dataset,ONS,UKEA,UK Economic Accounts,https://www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/unitedkingdomeconomicaccounts,https://www.ons.gov.uk/file?uri=/economy/grossdomesticproductgdp/datasets/unitedkingdomeconomicaccounts/current/ukea.csv,2024-06-28,2024-09-30,2024-07-01,TRUE,FALSE,NA
+dataset,ONS,UNEM,Claimant Count and Vacancies,https://www.ons.gov.uk/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/claimantcountandvacanciesdataset,https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/claimantcountandvacanciesdataset/current/unem.csv,2024-08-13,2024-09-10,2024-08-13,TRUE,FALSE,NA
+dataset,ONSx,PROD_LAD,Regional Productivity (LAD),NA,NA,NA,NA,NA,TRUE,FALSE,NA
+dataset,BOE,FEA,Custom,"https://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp?csv.x=yes&Datefrom=01/Jan/2005&Dateto=Now&SeriesCodes=IUMBEDR,IUMAMNPY,IUMAAMIJ,XUMAUSS,XUMAERS&CSVF=TN&UsingCodes=Y&VPD=Y&VFD=N","https://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp?csv.x=yes&Datefrom=01/Jan/2005&Dateto=Now&SeriesCodes=IUMBEDR,IUMAMNPY,IUMAAMIJ,XUMAUSS,XUMAERS&CSVF=TN&UsingCodes=Y&VPD=Y&VFD=N",NA,NA,NA,FALSE,FALSE,NA
+dataset,ONSx,RGVA,Regional GVA,NA,NA,NA,NA,NA,FALSE,TRUE,NA
+dataset,ONSx,RGVA_LAD,Regional GVA (LAD),NA,NA,NA,NA,NA,NA,NA,NA
+dataset,ONSx,RGVAI,Regional GVA (Income components),NA,NA,2024-04-24,NA,2024-05-22,FALSE,FALSE,NA
+dataset,NOMIS,BRES,Business Register and Employment Survey,NA,NA,NA,NA,NA,FALSE,TRUE,NA
+dataset,NOMIS,UKBC,UK Business Counts,NA,NA,NA,NA,NA,FALSE,TRUE,NA
+boundaries,ONSx,oa11,Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+boundaries,ONSx,lsoa11,Lower Layer Super Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+boundaries,ONSx,msoa11,Middle Layer Super Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+geographies,ONSx,oa11,Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+geographies,ONSx,lsoa11,Lower Layer Super Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+geographies,ONSx,msoa11,Middle Layer Super Output Areas,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+geographies,ONSx,lad,Local Authority Districts,NA,NA,NA,NA,NA,FALSE,FALSE,NA
+names,HOCL,msoanames,MSOA Names,https://houseofcommonslibrary.github.io/msoanames/MSOA-Names-Latest.csv,https://houseofcommonslibrary.github.io/msoanames/MSOA-Names-Latest.csv,NA,NA,NA,FALSE,FALSE,NA
+dataset,ONSx,RGFCF,Regional Gross Fixed Capital Formation,NA,NA,2023-12-08,NA,2024-05-21,TRUE,FALSE,NA
+NA,VOA,CTSOP,Council Tax Stock of Properties,NA,NA,NA,NA,NA,NA,TRUE,NA
+NA,ONSx,SAIE,Small area income estimates,NA,NA,NA,NA,NA,NA,TRUE,NA
+NA,NOMIS,SAPE,Small area population estimates,NA,NA,NA,NA,NA,NA,NA,NA
+NA,ONSx,HPSSA2,Median House Price by Property Type (MSOA),NA,NA,NA,NA,NA,NA,NA,NA
+NA,TEST,TEST,TEST,NA,NA,NA,NA,NA,NA,NA,NA
+NA,NOMIS,CC,Claimant Count,NA,NA,NA,NA,NA,NA,NA,NA
+NA,ONSx,RGDHI,Regional Gross Disposable Household Income,NA,NA,2023-09-14,NA,2024-05-21,NA,NA,NA
+NA,ONSx,RFDI,Regional Foreign Direct Investment,NA,NA,NA,NA,NA,NA,NA,NA
+dataset,ONSx,CONS,Output in the Construction Industry,NA,NA,2024-08-15,2024-09-11,2024-09-04,TRUE,TRUE,NA
+dataset,ONSx,INS1,Monthly Insolvencies by Type,NA,NA,2024-08-20,2024-09-20,2024-09-04,FALSE,FALSE,NA
+dataset,ONSx,INS2,Monthly Insolvencies by Industry,NA,NA,2024-04-26,2024-05-17,2024-04-29,FALSE,FALSE,NA


### PR DESCRIPTION
Updating edd_dict to include `page_url`. This will allow us to query the page for file links, update information and other metadata, captured via `extract_ons_metadata()`.