### PR TITLE
Add utils for checking ONS website for new next_update dates and add to run_ons_update.R pipeline

### DIFF
--- a/.pipelines/run_ons_update.R
+++ b/.pipelines/run_ons_update.R
@@ -1,3 +1,7 @@
 pkgload::load_all()
 
+check_next_update_dates()
+
+devtools::load_all()
+
 ons_update_datasets()

--- a/R/utils-data-to-update.r
+++ b/R/utils-data-to-update.r
@@ -1,7 +1,28 @@
 datasets_to_update <- function() {
   edd_dict |>
     dplyr::filter(
-      next_update <= Sys.Date() & next_update >= last_download
+      status &
+      next_update <= Sys.Date() &
+      next_update >= last_download
     ) |>
     dplyr::select(id)
+}
+
+check_next_update_dates <- function() {
+  datasets_with_no_next_update <- edd_dict |>
+    dplyr::filter(
+      status &
+      is.na(next_update) &
+      !is.na(page_url) &
+      grepl("ons.gov.uk", page_url)
+    )
+
+  for (id in datasets_with_no_next_update$id) {
+    meta <- extract_ons_metadata(datasets_with_no_next_update$page_url[datasets_with_no_next_update$id == id])
+    Sys.sleep(2)
+    if (!is.na(meta$next_update)) {
+      update_edd_dict(id, "next_update", meta$next_update)
+      message("Successfully found next update date of ", meta$next_update, " for dataset ", id)
+    }
+  }
 }


### PR DESCRIPTION
Provides a function which will poll ONS pages for datasets that in EDD have no next_update field and see if the page has been update. If it has, it writes that back to edd_dict.

run_ons_pipeline.R updated to add the call to this function and then to invoke devtools::load_all() to provide the GH action with a fresh version of edd_dict to run the updates against